### PR TITLE
feat: trustless fetch + support for multiformat base64

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
+    "ipfs-unixfs-exporter": "^13.6.2",
     "multiformats": "^13.3.2",
     "zod": "^3.24.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       express:
         specifier: ^4.21.2
         version: 4.21.2
+      ipfs-unixfs-exporter:
+        specifier: ^13.6.2
+        version: 13.6.2
       multiformats:
         specifier: ^13.3.2
         version: 13.3.2
@@ -1362,6 +1365,9 @@ packages:
   '@web3-storage/data-segment@5.3.0':
     resolution: {integrity: sha512-zFJ4m+pEKqtKatJNsFrk/2lHeFSbkXZ6KKXjBe7/2ayA9wAar7T/unewnOcZrrZTnCWmaxKsXWqdMFy9bXK9dw==}
 
+  abort-error@1.0.1:
+    resolution: {integrity: sha512-fxqCblJiIPdSXIUrxI0PL+eJG49QdP9SQ70qtB65MVAoMr2rASlOyAbJFOylfB467F/f+5BCLJJq58RYi7mGfg==}
+
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
@@ -1973,6 +1979,9 @@ packages:
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
+  hamt-sharding@3.0.6:
+    resolution: {integrity: sha512-nZeamxfymIWLpVcAN0CRrb7uVq3hCOGj9IcL6NMA6VVCVWqj+h9Jo/SmaWuS92AEDf1thmHsM5D5c70hM3j2Tg==}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -2031,9 +2040,21 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  interface-blockstore@5.3.1:
+    resolution: {integrity: sha512-nhgrQnz6yUQEqxTFLhlOBurQOy5lWlwCpgFmZ3GTObTVTQS9RZjK/JTozY6ty9uz2lZs7VFJSqwjWAltorJ4Vw==}
+
+  interface-store@6.0.2:
+    resolution: {integrity: sha512-KSFCXtBlNoG0hzwNa0RmhHtrdhzexp+S+UY2s0rWTBJyfdEIgn6i6Zl9otVqrcFYbYrneBT7hbmHQ8gE0C3umA==}
+
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
+
+  ipfs-unixfs-exporter@13.6.2:
+    resolution: {integrity: sha512-U3NkQHvQn5XzxtjSo1/GfoFIoXYY4hPgOlZG5RUrV5ScBI222b3jAHbHksXZuMy7sqPkA9ieeWdOmnG1+0nxyw==}
+
+  ipfs-unixfs@11.2.1:
+    resolution: {integrity: sha512-gUeeX63EFgiaMgcs0cUs2ZUPvlOeEZ38okjK8twdWGZX2jYd2rCk8k/TJ3DSRIDZ2t/aZMv6I23guxHaofZE3w==}
 
   ipfs-utils@9.0.14:
     resolution: {integrity: sha512-zIaiEGX18QATxgaS0/EOQNoo33W0islREABAcxXE8n7y2MGAlB+hdsxXn4J0hGZge8IqVQhW8sWIb+oJz2yEvg==}
@@ -2103,8 +2124,39 @@ packages:
   it-all@1.0.6:
     resolution: {integrity: sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A==}
 
+  it-filter@3.1.2:
+    resolution: {integrity: sha512-2AozaGjIvBBiB7t7MpVNug9kwofqmKSpvgW7zhuyvCs6xxDd6FrfvqyfYtlQTKLNP+Io1WeXko1UQhdlK4M0gg==}
+
   it-glob@1.0.2:
     resolution: {integrity: sha512-Ch2Dzhw4URfB9L/0ZHyY+uqOnKvBNeS/SMcRiPmJfpHiM0TsUZn+GkpcZxAoF3dJVdPm/PuIk3A4wlV7SUo23Q==}
+
+  it-last@3.0.7:
+    resolution: {integrity: sha512-qG4BTveE6Wzsz5voqaOtZAfZgXTJT+yiaj45vp5S0Vi8oOdgKlRqUeolfvWoMCJ9vwSc/z9pAaNYIza7gA851w==}
+
+  it-map@3.1.2:
+    resolution: {integrity: sha512-G3dzFUjTYHKumJJ8wa9dSDS3yKm8L7qDUnAgzemOD0UMztwm54Qc2v97SuUCiAgbOz/aibkSLImfoFK09RlSFQ==}
+
+  it-merge@3.0.9:
+    resolution: {integrity: sha512-TjY4WTiwe4ONmaKScNvHDAJj6Tw0UeQFp4JrtC/3Mq7DTyhytes7mnv5OpZV4gItpZcs0AgRntpT2vAy2cnXUw==}
+
+  it-parallel@3.0.9:
+    resolution: {integrity: sha512-FSg8T+pr7Z1VUuBxEzAAp/K1j8r1e9mOcyzpWMxN3mt33WFhroFjWXV1oYSSjNqcdYwxD/XgydMVMktJvKiDog==}
+
+  it-peekable@3.0.6:
+    resolution: {integrity: sha512-odk9wn8AwFQipy8+tFaZNRCM62riraKZJRysfbmOett9wgJumCwgZFzWUBUwMoiQapEcEVGwjDpMChZIi+zLuQ==}
+
+  it-pipe@3.0.1:
+    resolution: {integrity: sha512-sIoNrQl1qSRg2seYSBH/3QxWhJFn9PKYvOf/bHdtCBF0bnghey44VyASsWzn5dAx0DCDDABq1hZIuzKmtBZmKA==}
+    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+
+  it-pushable@3.2.3:
+    resolution: {integrity: sha512-gzYnXYK8Y5t5b/BnJUr7glfQLO4U5vyb05gPx/TyTw+4Bv1zM9gFk4YsOrnulWefMewlphCjKkakFvj1y99Tcg==}
+
+  it-queueless-pushable@2.0.0:
+    resolution: {integrity: sha512-MlNnefWT/ntv5fesrHpxwVIu6ZdtlkN0A4aaJiE5wnmPMBv9ttiwX3UEMf78dFwIj5ZNaU9usYXg4swMEpUNJQ==}
+
+  it-stream-types@2.0.2:
+    resolution: {integrity: sha512-Rz/DEZ6Byn/r9+/SBCuJhpPATDF9D+dz5pbgSUyBsCDtza6wtNATrz/jz1gDyNanC3XdLboriHnOC925bZRBww==}
 
   it-to-stream@1.0.0:
     resolution: {integrity: sha512-pLULMZMAB/+vbdvbZtebC0nWBTbG581lk6w8P7DfIIIKUfa8FbY7Oi0FxZcFPbxvISs7A9E+cMpLDBc1XhpAOA==}
@@ -2390,9 +2442,17 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  p-queue@8.1.0:
+    resolution: {integrity: sha512-mxLDbbGIBEXTJL0zEx8JIylaj3xQ7Z/7eEVjcF9fJX4DBiH9oqe+oahYnlKKxm0Ci9TlWTyhSHgygxMxjIB2jw==}
+    engines: {node: '>=18'}
+
   p-retry@5.1.2:
     resolution: {integrity: sha512-couX95waDu98NfNZV+i/iLt+fdVxmI7CbrrdC2uDWfPdUAApyxT4wmDlyOtR5KtTDmkDO0zDScDjDou9YHhd9g==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  p-timeout@6.1.4:
+    resolution: {integrity: sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==}
+    engines: {node: '>=14.16'}
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
@@ -2481,9 +2541,15 @@ packages:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
 
+  progress-events@1.0.1:
+    resolution: {integrity: sha512-MOzLIwhpt64KIVN64h1MwdKWiyKFNc/S6BoYKPIVUHFg0/eIEyBulhWCgn678v/4c0ri3FdGuzXymNCv02MUIw==}
+
   protobufjs@7.4.0:
     resolution: {integrity: sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==}
     engines: {node: '>=12.0.0'}
+
+  protons-runtime@5.5.0:
+    resolution: {integrity: sha512-EsALjF9QsrEk6gbCx3lmfHxVN0ah7nG3cY7GySD4xf4g8cr7g543zB88Foh897Sr1RQJ9yDCUsoT1i1H/cVUFA==}
 
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
@@ -2511,6 +2577,9 @@ packages:
 
   rabin-rs@2.1.0:
     resolution: {integrity: sha512-5y72gAXPzIBsAMHcpxZP8eMDuDT98qMP1BqSDHRbHkJJXEgWIN1lA47LxUqzsK6jknOJtgfkQr9v+7qMlFDm6g==}
+
+  race-signal@1.1.3:
+    resolution: {integrity: sha512-Mt2NznMgepLfORijhQMncE26IhkmjEphig+/1fKC0OtaKwys/gpvpmswSjoN01SS+VO951mj0L4VIDXdXsjnfA==}
 
   range-parser@1.2.0:
     resolution: {integrity: sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A==}
@@ -2708,6 +2777,9 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  sparse-array@1.3.2:
+    resolution: {integrity: sha512-ZT711fePGn3+kQyLuv1fpd3rNSkNF8vd5Kv2D+qnOANeyKs3fx6bUMGWRPvgTTcYV64QMqZKZwcuaQSP3AZ0tg==}
+
   spawn-rx@5.1.2:
     resolution: {integrity: sha512-/y7tJKALVZ1lPzeZZB9jYnmtrL7d0N2zkorii5a7r7dhHkWIuLTzZpZzMJLK1dmYRgX/NCc4iarTO3F7BS2c/A==}
 
@@ -2886,6 +2958,9 @@ packages:
     resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uint8-varint@2.0.4:
+    resolution: {integrity: sha512-FwpTa7ZGA/f/EssWAb5/YV6pHgVF1fViKdW8cWaEarjB8t7NyofSWBdOTyFPaGuUG4gx3v1O3PQ8etsiOs3lcw==}
 
   uint8arraylist@2.4.8:
     resolution: {integrity: sha512-vc1PlGOzglLF0eae1M8mLRTBivsvrGsdmJ5RbK3e+QRvRLOZfZhQROTwH/OfyF3+ZVUg9/8hE8bmKP2CvP9quQ==}
@@ -4306,6 +4381,8 @@ snapshots:
       multiformats: 13.3.2
       sync-multihash-sha2: 1.0.0
 
+  abort-error@1.0.1: {}
+
   accepts@1.3.8:
     dependencies:
       mime-types: 2.1.35
@@ -5014,6 +5091,11 @@ snapshots:
 
   graphemer@1.4.0: {}
 
+  hamt-sharding@3.0.6:
+    dependencies:
+      sparse-array: 1.3.2
+      uint8arrays: 5.1.0
+
   has-flag@4.0.0: {}
 
   has-symbols@1.1.0: {}
@@ -5061,7 +5143,38 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  interface-blockstore@5.3.1:
+    dependencies:
+      interface-store: 6.0.2
+      multiformats: 13.3.2
+
+  interface-store@6.0.2: {}
+
   ipaddr.js@1.9.1: {}
+
+  ipfs-unixfs-exporter@13.6.2:
+    dependencies:
+      '@ipld/dag-cbor': 9.2.2
+      '@ipld/dag-json': 10.2.3
+      '@ipld/dag-pb': 4.1.3
+      '@multiformats/murmur3': 2.1.8
+      hamt-sharding: 3.0.6
+      interface-blockstore: 5.3.1
+      ipfs-unixfs: 11.2.1
+      it-filter: 3.1.2
+      it-last: 3.0.7
+      it-map: 3.1.2
+      it-parallel: 3.0.9
+      it-pipe: 3.0.1
+      it-pushable: 3.2.3
+      multiformats: 13.3.2
+      p-queue: 8.1.0
+      progress-events: 1.0.1
+
+  ipfs-unixfs@11.2.1:
+    dependencies:
+      protons-runtime: 5.5.0
+      uint8arraylist: 2.4.8
 
   ipfs-utils@9.0.14(encoding@0.1.13):
     dependencies:
@@ -5135,10 +5248,48 @@ snapshots:
 
   it-all@1.0.6: {}
 
+  it-filter@3.1.2:
+    dependencies:
+      it-peekable: 3.0.6
+
   it-glob@1.0.2:
     dependencies:
       '@types/minimatch': 3.0.5
       minimatch: 3.1.2
+
+  it-last@3.0.7: {}
+
+  it-map@3.1.2:
+    dependencies:
+      it-peekable: 3.0.6
+
+  it-merge@3.0.9:
+    dependencies:
+      it-queueless-pushable: 2.0.0
+
+  it-parallel@3.0.9:
+    dependencies:
+      p-defer: 4.0.1
+
+  it-peekable@3.0.6: {}
+
+  it-pipe@3.0.1:
+    dependencies:
+      it-merge: 3.0.9
+      it-pushable: 3.2.3
+      it-stream-types: 2.0.2
+
+  it-pushable@3.2.3:
+    dependencies:
+      p-defer: 4.0.1
+
+  it-queueless-pushable@2.0.0:
+    dependencies:
+      abort-error: 1.0.1
+      p-defer: 4.0.1
+      race-signal: 1.1.3
+
+  it-stream-types@2.0.2: {}
 
   it-to-stream@1.0.0:
     dependencies:
@@ -5395,10 +5546,17 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  p-queue@8.1.0:
+    dependencies:
+      eventemitter3: 5.0.1
+      p-timeout: 6.1.4
+
   p-retry@5.1.2:
     dependencies:
       '@types/retry': 0.12.1
       retry: 0.13.1
+
+  p-timeout@6.1.4: {}
 
   package-json-from-dist@1.0.1: {}
 
@@ -5457,6 +5615,8 @@ snapshots:
 
   prismjs@1.30.0: {}
 
+  progress-events@1.0.1: {}
+
   protobufjs@7.4.0:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
@@ -5471,6 +5631,12 @@ snapshots:
       '@protobufjs/utf8': 1.1.0
       '@types/node': 22.13.13
       long: 5.3.1
+
+  protons-runtime@5.5.0:
+    dependencies:
+      uint8-varint: 2.0.4
+      uint8arraylist: 2.4.8
+      uint8arrays: 5.1.0
 
   proxy-addr@2.0.7:
     dependencies:
@@ -5494,6 +5660,8 @@ snapshots:
   queue-microtask@1.2.3: {}
 
   rabin-rs@2.1.0: {}
+
+  race-signal@1.1.3: {}
 
   range-parser@1.2.0: {}
 
@@ -5745,6 +5913,8 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  sparse-array@1.3.2: {}
+
   spawn-rx@5.1.2:
     dependencies:
       debug: 4.4.0
@@ -5911,6 +6081,11 @@ snapshots:
       mime-types: 3.0.1
 
   typescript@5.8.2: {}
+
+  uint8-varint@2.0.4:
+    dependencies:
+      uint8arraylist: 2.4.8
+      uint8arrays: 5.1.0
 
   uint8arraylist@2.4.8:
     dependencies:

--- a/src/core/server/tools/retrieve.ts
+++ b/src/core/server/tools/retrieve.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { StorachaClient } from '../../storage/client.js';
 import { StorageConfig } from 'src/core/storage/types.js';
+import * as dagJSON from '@ipld/dag-json';
 
 type RetrieveInput = {
   filepath: string;
@@ -31,7 +32,7 @@ export const retrieveTool = (storageConfig: StorageConfig) => ({
         content: [
           {
             type: 'text' as const,
-            text: JSON.stringify(result),
+            text: dagJSON.stringify(result),
           },
         ],
       };

--- a/src/core/server/tools/retrieve.ts
+++ b/src/core/server/tools/retrieve.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod';
 import { StorachaClient } from '../../storage/client.js';
 import { StorageConfig } from 'src/core/storage/types.js';
-import { isValidCID } from 'src/core/storage/utils.js';
 
 type RetrieveInput = {
   filepath: string;

--- a/src/core/server/tools/retrieve.ts
+++ b/src/core/server/tools/retrieve.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { StorachaClient } from '../../storage/client.js';
 import { StorageConfig } from 'src/core/storage/types.js';
+import { isValidCID } from 'src/core/storage/utils.js';
 
 type RetrieveInput = {
   filepath: string;

--- a/test/integration/stdio-mcp-server.test.ts
+++ b/test/integration/stdio-mcp-server.test.ts
@@ -115,6 +115,7 @@ const isCI = process.env.CI === 'true';
     // Parse upload response
     const uploadResult = JSON.parse(uploadContent.text);
     expect(uploadResult).toHaveProperty('root');
+<<<<<<< HEAD
     // The root can be either a string or an object with toString method
     expect(uploadResult.root).toBeDefined();
     expect(uploadResult).toHaveProperty('url');
@@ -131,6 +132,16 @@ const isCI = process.env.CI === 'true';
     // Check the first file entry (could be in different formats depending on serialization)
     const firstFile = fileEntries[0];
     expect(firstFile).toBeDefined();
+=======
+    expect(typeof uploadResult.root).toBe('string');
+    expect(uploadResult).toHaveProperty('url');
+    expect(uploadResult).toHaveProperty('files');
+    expect(Array.isArray(uploadResult.files)).toBe(true);
+    expect(uploadResult.files.length).toBeGreaterThan(0);
+    expect(uploadResult.files[0]).toHaveProperty('name');
+    expect(uploadResult.files[0]).toHaveProperty('url');
+    expect(uploadResult.files[0]).toHaveProperty('cid');
+>>>>>>> 8ed405d (feat: preserve filename using uploadDirectory)
   }, 30_000); // Increase the timeout for upload test
 
   it('should retrieve a file', async () => {

--- a/test/integration/stdio-mcp-server.test.ts
+++ b/test/integration/stdio-mcp-server.test.ts
@@ -115,7 +115,6 @@ const isCI = process.env.CI === 'true';
     // Parse upload response
     const uploadResult = JSON.parse(uploadContent.text);
     expect(uploadResult).toHaveProperty('root');
-<<<<<<< HEAD
     // The root can be either a string or an object with toString method
     expect(uploadResult.root).toBeDefined();
     expect(uploadResult).toHaveProperty('url');
@@ -132,16 +131,14 @@ const isCI = process.env.CI === 'true';
     // Check the first file entry (could be in different formats depending on serialization)
     const firstFile = fileEntries[0];
     expect(firstFile).toBeDefined();
-=======
-    expect(typeof uploadResult.root).toBe('string');
+    // The root can be either a string or an object with toString method
+    expect(uploadResult.root).toBeDefined();
     expect(uploadResult).toHaveProperty('url');
     expect(uploadResult).toHaveProperty('files');
-    expect(Array.isArray(uploadResult.files)).toBe(true);
-    expect(uploadResult.files.length).toBeGreaterThan(0);
-    expect(uploadResult.files[0]).toHaveProperty('name');
-    expect(uploadResult.files[0]).toHaveProperty('url');
-    expect(uploadResult.files[0]).toHaveProperty('cid');
->>>>>>> 8ed405d (feat: preserve filename using uploadDirectory)
+
+    // Test that files is an object with at least one entry
+    expect(typeof uploadResult.files).toBe('object');
+    expect(uploadResult.files).not.toBeNull();
   }, 30_000); // Increase the timeout for upload test
 
   it('should retrieve a file', async () => {

--- a/test/unit/core/server/tools/retrieve.test.ts
+++ b/test/unit/core/server/tools/retrieve.test.ts
@@ -5,6 +5,14 @@ import { Signer } from '@ucanto/principal/ed25519';
 import { Delegation, Capabilities } from '@ucanto/interface';
 import { StorachaClient } from '../../../../../src/core/storage/client.js';
 
+// // Mock isValidCID function from the utils.js file
+// vi.mock('../../../../../src/core/storage/utils.js', () => ({
+//   isValidCID: vi.fn().mockImplementation((cid) => {
+//     // Simple mock that considers any non-empty string a valid CID
+//     return typeof cid === 'string' && cid.trim().length > 0;
+//   }),
+// }));
+
 // Create mocks
 const mockSigner = {
   did: () => 'did:key:mock',

--- a/test/unit/core/server/tools/retrieve.test.ts
+++ b/test/unit/core/server/tools/retrieve.test.ts
@@ -5,14 +5,6 @@ import { Signer } from '@ucanto/principal/ed25519';
 import { Delegation, Capabilities } from '@ucanto/interface';
 import { StorachaClient } from '../../../../../src/core/storage/client.js';
 
-// // Mock isValidCID function from the utils.js file
-// vi.mock('../../../../../src/core/storage/utils.js', () => ({
-//   isValidCID: vi.fn().mockImplementation((cid) => {
-//     // Simple mock that considers any non-empty string a valid CID
-//     return typeof cid === 'string' && cid.trim().length > 0;
-//   }),
-// }));
-
 // Create mocks
 const mockSigner = {
   did: () => 'did:key:mock',

--- a/test/unit/core/storage/config.test.ts
+++ b/test/unit/core/storage/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { loadConfig } from '../../../src/core/storage/config.js';
+import { loadConfig } from '../../../../src/core/storage/config.js';
 
 // Mock the required dependencies
 vi.mock('@ucanto/principal/ed25519', () => ({
@@ -16,13 +16,17 @@ vi.mock('@ucanto/principal/ed25519', () => ({
   },
 }));
 
-vi.mock('../../../src/core/storage/utils.js', () => ({
-  parseDelegation: vi.fn().mockResolvedValue({
-    root: {
-      did: () => 'did:key:test',
-      sign: vi.fn(),
-      verify: vi.fn(),
-    },
+// Mock the parseDelegation function to avoid base64 validation issues
+vi.mock('../../../../src/core/storage/utils.js', () => ({
+  parseDelegation: vi.fn().mockImplementation(async delegationStr => {
+    // Always return a valid delegation object regardless of input
+    return {
+      root: {
+        did: () => 'did:key:test',
+        sign: vi.fn(),
+        verify: vi.fn(),
+      },
+    };
   }),
 }));
 

--- a/test/unit/core/storage/utils.test.ts
+++ b/test/unit/core/storage/utils.test.ts
@@ -1,9 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
-  normalizeIpfsPath,
-  isValidCID,
-  parseIpfsPath,
   parseDelegation,
+  parseIpfsPath,
+  normalizeIpfsPath,
 } from '../../../../src/core/storage/utils.js';
 import { IpfsPathError } from '../../../../src/core/storage/types.js';
 import { CID } from 'multiformats';
@@ -155,17 +154,6 @@ describe('Storage Utils', () => {
       expect(normalizeIpfsPath('http://example.com/ipfs/file.txt')).toBe(
         'http://example.com/ipfs/file.txt'
       );
-    });
-  });
-
-  describe('isValidCID', () => {
-    it('should return true for valid CIDs', () => {
-      expect(isValidCID(VALID_CID)).toBe(true);
-    });
-
-    it('should return false for invalid CIDs', () => {
-      expect(isValidCID('not-a-cid')).toBe(false);
-      expect(isValidCID('')).toBe(false);
     });
   });
 

--- a/test/unit/test-config.ts
+++ b/test/unit/test-config.ts
@@ -1,1 +1,0 @@
-export const TEST_DELEGATION = '';


### PR DESCRIPTION
### Main Changes
- Trustless fetching was added, which ensures data integrity by validating the CID (Content Identifier) after retrieval rather than blindly trusting the received bytes. This is implemented by fetching data as CAR files and using IPLD/IPFS libs to reconstruct and verify the content against its expected CID.
- Enabled multiformat base64 support: enhanced the `base64ToBytes` function to handle the 'm' prefix used by the multiformats library, making our system compatible with various encoding standards. This allows seamless integration with different data sources and tools in the IPFS ecosystem while maintaining backward compatibility with standard base64 encoding.


Resolves: https://github.com/storacha/mcp-storage-server/issues/8
Resolves: https://github.com/storacha/mcp-storage-server/issues/6