### PR TITLE
fix: read package.json from dist folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.ts",
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "build": "pnpm typecheck && tsc",
+    "build": "pnpm typecheck && tsc && cp package.json dist/package.json",
     "start": "node dist/index.js",
     "start:stdio": "MCP_TRANSPORT_MODE=stdio pnpm start",
     "start:sse": "MCP_TRANSPORT_MODE=sse pnpm start",

--- a/src/core/storage/client.ts
+++ b/src/core/storage/client.ts
@@ -20,7 +20,8 @@ import { DEFAULT_GATEWAY_URL } from './config.js';
 import { Principal } from '@ucanto/interface';
 import { DID } from '@ucanto/core';
 import { readFileSync } from 'fs';
-import { join } from 'path';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
 import { parseIpfsPath, streamToBase64, base64ToBytes } from './utils.js';
 import { CID, UnknownLink } from 'multiformats';
 import { CarReader } from '@ipld/car';
@@ -32,7 +33,10 @@ import { Readable } from 'node:stream';
  */
 const STORAGE_SERVICE_DID = 'did:web:web3.storage';
 
-const packageJson = JSON.parse(readFileSync(join(process.cwd(), 'package.json'), 'utf-8'));
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const rootDir = join(__dirname, '../../..');
+const packageJson = JSON.parse(readFileSync(join(rootDir, 'package.json'), 'utf-8'));
 
 /**
  * Add the major version of the MCP server to the headers of the Storacha client.


### PR DESCRIPTION
### Changes
- Reading the `package.json` directly from the dist folder, so we can start the MCP server from any other folder.