### PR TITLE
fix: use standard base64 encode

### DIFF
--- a/src/core/server/tools/retrieve.ts
+++ b/src/core/server/tools/retrieve.ts
@@ -5,10 +5,10 @@ import * as dagJSON from '@ipld/dag-json';
 
 type RetrieveInput = {
   filepath: string;
+  useMultiformatBase64?: boolean;
 };
 
-// Simplified schema that just validates that filepath is a non-empty string
-// The actual parsing/validation happens in the client
+// Schema with filepath and optional useMultiformatBase64 flag
 const retrieveInputSchema = z.object({
   filepath: z
     .string()
@@ -16,6 +16,10 @@ const retrieveInputSchema = z.object({
     .describe(
       'The path to retrieve in format: CID/filename, /ipfs/CID/filename, or ipfs://CID/filename'
     ),
+  useMultiformatBase64: z
+    .boolean()
+    .optional()
+    .describe('Whether to use multiformat base64 encoding instead of standard base64'),
 });
 
 export const retrieveTool = (storageConfig: StorageConfig) => ({
@@ -26,7 +30,9 @@ export const retrieveTool = (storageConfig: StorageConfig) => ({
   handler: async (input: RetrieveInput) => {
     try {
       const client = new StorachaClient(storageConfig);
-      const result = await client.retrieve(input.filepath);
+      const result = await client.retrieve(input.filepath, {
+        useMultiformatBase64: input.useMultiformatBase64,
+      });
 
       return {
         content: [

--- a/src/core/storage/client.ts
+++ b/src/core/storage/client.ts
@@ -5,6 +5,7 @@ import {
   RetrieveResult,
   UploadOptions,
   UploadFile,
+  RetrieveOptions,
 } from './types.js';
 import * as Storage from '@storacha/client';
 import { StoreMemory } from '@storacha/client/stores/memory';
@@ -188,10 +189,11 @@ export class StorachaClient implements StorageClient {
   /**
    * Retrieve a file from the gateway
    * @param filepath - Path string in the format "cid/filename", "/ipfs/cid/filename", or "ipfs://cid/filename"
+   * @param options - Retrieve options
    * @returns The file data and metadata
    * @throws Error if the response is not successful
    */
-  async retrieve(filepath: string): Promise<RetrieveResult> {
+  async retrieve(filepath: string, options?: RetrieveOptions): Promise<RetrieveResult> {
     // Parse the filepath into a Resource object
     const resource = parseIpfsPath(filepath);
 
@@ -214,8 +216,9 @@ export class StorachaClient implements StorageClient {
       },
     });
 
-    // Convert the content to a base64 string
-    const base64Data = await streamToBase64(Readable.from(entry.content()));
+    // Convert the content to a base64 string based on the options
+    const useMultiformatBase64 = options?.useMultiformatBase64 ?? false;
+    const base64Data = await streamToBase64(Readable.from(entry.content()), useMultiformatBase64);
     const contentType = response.headers.get('content-type');
 
     return {

--- a/src/core/storage/types.ts
+++ b/src/core/storage/types.ts
@@ -84,6 +84,14 @@ export interface RetrieveResult {
 }
 
 /**
+ * Options for retrieving files
+ */
+export interface RetrieveOptions {
+  /** Whether to use multiformat base64 encoding instead of standard base64 */
+  useMultiformatBase64?: boolean;
+}
+
+/**
  * Interface for storage operations
  */
 export interface StorageClient {
@@ -103,6 +111,7 @@ export interface StorageClient {
   /**
    * Retrieve a file from storage
    * @param filepath - Path string in the format "cid/filename", "/ipfs/cid/filename", or "ipfs://cid/filename"
+   * @param options - Retrieve options
    */
-  retrieve(filepath: string): Promise<RetrieveResult>;
+  retrieve(filepath: string, options?: RetrieveOptions): Promise<RetrieveResult>;
 }

--- a/src/core/storage/utils.ts
+++ b/src/core/storage/utils.ts
@@ -119,9 +119,13 @@ export function base64ToBytes(base64Str: string): Uint8Array {
 /**
  * Converts a Readable stream to a base64 encoded string
  * @param stream - The Readable stream to convert
+ * @param useMultiformatBase64 - Whether to use multiformat base64 encoding instead of standard base64
  * @returns A Promise that resolves to the base64 encoded string
  */
-export async function streamToBase64(stream: Readable): Promise<string> {
+export async function streamToBase64(
+  stream: Readable,
+  useMultiformatBase64 = false
+): Promise<string> {
   const chunks: Uint8Array[] = [];
   for await (const chunk of stream) {
     chunks.push(chunk);
@@ -135,6 +139,6 @@ export async function streamToBase64(stream: Readable): Promise<string> {
     offset += chunk.length;
   }
 
-  // Convert to base64 using multiformats
-  return base64.encode(bytes);
+  // Convert to either standard base64 or multiformat base64 depending on the flag
+  return useMultiformatBase64 ? base64.encode(bytes) : Buffer.from(bytes).toString('base64');
 }

--- a/test/unit/core/server/tools/retrieve.test.ts
+++ b/test/unit/core/server/tools/retrieve.test.ts
@@ -60,7 +60,9 @@ describe('Retrieve Tool', () => {
         },
       ],
     });
-    expect(StorachaClient.prototype.retrieve).toHaveBeenCalledWith('test-cid/file.txt');
+    expect(StorachaClient.prototype.retrieve).toHaveBeenCalledWith('test-cid/file.txt', {
+      useMultiformatBase64: undefined,
+    });
   });
 
   it('should handle errors gracefully', async () => {
@@ -81,7 +83,9 @@ describe('Retrieve Tool', () => {
         },
       ],
     });
-    expect(StorachaClient.prototype.retrieve).toHaveBeenCalledWith('error-path/file.txt');
+    expect(StorachaClient.prototype.retrieve).toHaveBeenCalledWith('error-path/file.txt', {
+      useMultiformatBase64: undefined,
+    });
   });
 
   it('should handle non-Error objects', async () => {
@@ -100,7 +104,9 @@ describe('Retrieve Tool', () => {
         },
       ],
     });
-    expect(StorachaClient.prototype.retrieve).toHaveBeenCalledWith('non-error-path/file.txt');
+    expect(StorachaClient.prototype.retrieve).toHaveBeenCalledWith('non-error-path/file.txt', {
+      useMultiformatBase64: undefined,
+    });
   });
 
   it('should accept various IPFS path formats', async () => {
@@ -117,7 +123,8 @@ describe('Retrieve Tool', () => {
       filepath: 'bafybeibv7vzycdcnydl5n5lbws6lul2omkm6a6b5wmqt77sicrwnhesy7y/bmoney.txt',
     });
     expect(retrieveMock).toHaveBeenLastCalledWith(
-      'bafybeibv7vzycdcnydl5n5lbws6lul2omkm6a6b5wmqt77sicrwnhesy7y/bmoney.txt'
+      'bafybeibv7vzycdcnydl5n5lbws6lul2omkm6a6b5wmqt77sicrwnhesy7y/bmoney.txt',
+      { useMultiformatBase64: undefined }
     );
 
     // Test with /ipfs/ prefix
@@ -125,7 +132,8 @@ describe('Retrieve Tool', () => {
       filepath: '/ipfs/bafybeibv7vzycdcnydl5n5lbws6lul2omkm6a6b5wmqt77sicrwnhesy7y/bmoney.txt',
     });
     expect(retrieveMock).toHaveBeenLastCalledWith(
-      '/ipfs/bafybeibv7vzycdcnydl5n5lbws6lul2omkm6a6b5wmqt77sicrwnhesy7y/bmoney.txt'
+      '/ipfs/bafybeibv7vzycdcnydl5n5lbws6lul2omkm6a6b5wmqt77sicrwnhesy7y/bmoney.txt',
+      { useMultiformatBase64: undefined }
     );
 
     // Test with ipfs:// protocol
@@ -133,7 +141,38 @@ describe('Retrieve Tool', () => {
       filepath: 'ipfs://bafybeibv7vzycdcnydl5n5lbws6lul2omkm6a6b5wmqt77sicrwnhesy7y/bmoney.txt',
     });
     expect(retrieveMock).toHaveBeenLastCalledWith(
-      'ipfs://bafybeibv7vzycdcnydl5n5lbws6lul2omkm6a6b5wmqt77sicrwnhesy7y/bmoney.txt'
+      'ipfs://bafybeibv7vzycdcnydl5n5lbws6lul2omkm6a6b5wmqt77sicrwnhesy7y/bmoney.txt',
+      { useMultiformatBase64: undefined }
+    );
+  });
+
+  it('should pass useMultiformatBase64 flag to the client', async () => {
+    // Mock the client's retrieve method
+    const retrieveMock = vi.spyOn(StorachaClient.prototype, 'retrieve').mockResolvedValue({
+      data: Buffer.from('test-data').toString('base64'),
+      type: 'text/plain',
+    });
+
+    const tool = retrieveTool(mockStorageConfig);
+
+    // Test with useMultiformatBase64 set to true
+    await tool.handler({
+      filepath: 'bafybeibv7vzycdcnydl5n5lbws6lul2omkm6a6b5wmqt77sicrwnhesy7y/bmoney.txt',
+      useMultiformatBase64: true,
+    });
+    expect(retrieveMock).toHaveBeenLastCalledWith(
+      'bafybeibv7vzycdcnydl5n5lbws6lul2omkm6a6b5wmqt77sicrwnhesy7y/bmoney.txt',
+      { useMultiformatBase64: true }
+    );
+
+    // Test with useMultiformatBase64 set to false
+    await tool.handler({
+      filepath: 'bafybeibv7vzycdcnydl5n5lbws6lul2omkm6a6b5wmqt77sicrwnhesy7y/bmoney.txt',
+      useMultiformatBase64: false,
+    });
+    expect(retrieveMock).toHaveBeenLastCalledWith(
+      'bafybeibv7vzycdcnydl5n5lbws6lul2omkm6a6b5wmqt77sicrwnhesy7y/bmoney.txt',
+      { useMultiformatBase64: false }
     );
   });
 


### PR DESCRIPTION
### Context
- While integrating it with Cursor to store chat history, Cursor was failing to decode the retrieved content in multiformat base64 and had to perform additional steps to extract the data.

### Changes
- Using the standard base64 encode because that's what agents and models expect. 
- If the users decide to get the result encoded in multiformat base64 they provide the `useMultiformatBase64=true` in the retrieve operation. By default it will always use standard base64.