### PR TITLE
feat: rest mode for storage server

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Get started with the Storacha MCP Storage Server in just a few simple steps.
          "command": "node",
          "args": ["./dist/index.js"],
          "env": {
-           // The server also supports `sse` mode, the default is `stdio`.
+           // The server supports `stdio`, `sse`, and `rest` modes, the default is `stdio`.
            "MCP_TRANSPORT_MODE": "stdio",
            // The Storacha Agent private key that is authorized to store data into the Space.
            "PRIVATE_KEY": "<agent_private_key>",
@@ -108,6 +108,22 @@ Get started with the Storacha MCP Storage Server in just a few simple steps.
    ```
 
    _Replace `<agent_private_key>` with the PrivateKey you created in step 3. Then, replace the `<base64_delegation>` with the delegation you created in step 3._
+
+   ### REST Mode and Cloud Hosting
+
+   The Storacha MCP Storage Server supports REST transport mode, which is compatible with MCP.so cloud hosting. To use REST mode:
+
+   ```jsonc
+   {
+     "mcpServers": {
+       "storacha-storage-server-rest": {
+         "url": "http://localhost:3001/rest",
+       },
+     },
+   }
+   ```
+
+   For more information on deploying to MCP.so cloud, see the [integrations.md](https://github.com/storacha/mcp-storage-server/blob/main/docs/integrations.md#mcpso-cloud-hosting) guide.
 
    _:warning: There are several ways to configure MCP clients, please read the [integrations.md](https://github.com/storacha/mcp-storage-server/blob/main/docs/integrations.md) guide for more information._
 

--- a/chatmcp.yaml
+++ b/chatmcp.yaml
@@ -1,0 +1,50 @@
+params:
+  type: object
+  properties:
+    PRIVATE_KEY:
+      type: string
+      description: The Storacha Agent private key
+    DELEGATION:
+      type: string
+      description: Base64 encoded delegation
+  required:
+    - PRIVATE_KEY
+    - DELEGATION
+
+rest:
+  name: storacha-storage
+  port: 3001
+  endpoint: /rest
+  dockerfile: ./Dockerfile
+
+docker:
+  command: |
+    docker run -i --rm -p 3001:3001 -e PRIVATE_KEY={PRIVATE_KEY} -e DELEGATION={DELEGATION} -e MCP_TRANSPORT_MODE=rest -e MCP_SERVER_PORT=3001 storacha-mcp-server
+  config: |
+    {
+      "mcpServers": {
+        "storacha-storage": {
+          "command": "docker",
+          "args": [
+            "run",
+            "-i",
+            "--rm",
+            "-p",
+            "3001:3001",
+            "-e",
+            "PRIVATE_KEY",
+            "-e",
+            "DELEGATION",
+            "-e",
+            "MCP_TRANSPORT_MODE=rest",
+            "-e",
+            "MCP_SERVER_PORT=3001",
+            "storacha-mcp-server"
+          ],
+          "env": {
+            "PRIVATE_KEY": "YOUR_PRIVATE_KEY_HERE",
+            "DELEGATION": "YOUR_DELEGATION_HERE"
+          }
+        }
+      }
+    } 

--- a/index.ts
+++ b/index.ts
@@ -9,6 +9,7 @@ import { loadConfig as loadStorageConfig } from './src/core/storage/config.js';
  * Server mode is determined by the MCP_TRANSPORT_MODE environment variable:
  * - 'stdio': Starts the server in stdio mode (default)
  * - 'http': Starts the server in HTTP mode with SSE transport
+ * - 'rest': Starts the server in REST mode (MCP.so Cloud)
  */
 async function main() {
   try {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "start": "node dist/index.js",
     "start:stdio": "MCP_TRANSPORT_MODE=stdio pnpm start",
     "start:sse": "MCP_TRANSPORT_MODE=sse pnpm start",
+    "start:rest": "MCP_TRANSPORT_MODE=rest pnpm start",
     "dev": "tsc-watch --onSuccess \"node dist/index.js\"",
     "clean": "rm -rf dist",
     "lint": "eslint \"src/**/*.{ts,tsx}\" \"test/**/*.{ts,tsx}\"",
@@ -23,9 +24,11 @@
     "test:coverage": "pnpm typecheck && vitest run --coverage",
     "test": "pnpm typecheck && vitest run",
     "test:integration": "pnpm build && pnpm typecheck && vitest run test/integration/**.test.ts",
+    "test:integration:only": "pnpm build && pnpm typecheck && vitest run",
     "inspect": "pnpm build && npx @modelcontextprotocol/inspector node dist/index.js",
     "inspect:sse": "MCP_TRANSPORT_MODE=sse pnpm inspect",
     "inspect:stdio": "MCP_TRANSPORT_MODE=stdio pnpm inspect",
+    "inspect:rest": "MCP_TRANSPORT_MODE=rest pnpm inspect",
     "prepare": "husky install",
     "prepublishOnly": "pnpm build"
   },
@@ -51,6 +54,7 @@
     "dist"
   ],
   "dependencies": {
+    "@chatmcp/sdk": "^1.0.6",
     "@ipld/car": "^5.4.0",
     "@ipld/dag-json": "^10.2.3",
     "@ipld/unixfs": "^3.0.0",
@@ -72,6 +76,7 @@
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.1",
     "@types/node": "^22.13.13",
+    "@types/node-fetch": "^2.6.12",
     "@typescript-eslint/eslint-plugin": "^8.29.0",
     "@typescript-eslint/parser": "^8.29.0",
     "@vitest/coverage-v8": "3.0.9",
@@ -79,6 +84,7 @@
     "eslint-config-prettier": "^10.1.1",
     "husky": "^9.1.7",
     "lint-staged": "^15.5.0",
+    "node-fetch": "^3.3.2",
     "prettier": "^3.5.3",
     "ts-node": "^10.9.2",
     "tsc-watch": "^6.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@chatmcp/sdk':
+        specifier: ^1.0.6
+        version: 1.0.6
       '@ipld/car':
         specifier: ^5.4.0
         version: 5.4.0
@@ -66,6 +69,9 @@ importers:
       '@types/node':
         specifier: ^22.13.13
         version: 22.13.13
+      '@types/node-fetch':
+        specifier: ^2.6.12
+        version: 2.6.12
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.29.0
         version: 8.29.0(@typescript-eslint/parser@8.29.0(eslint@9.23.0)(typescript@5.8.2))(eslint@9.23.0)(typescript@5.8.2)
@@ -87,6 +93,9 @@ importers:
       lint-staged:
         specifier: ^15.5.0
         version: 15.5.0
+      node-fetch:
+        specifier: ^3.3.2
+        version: 3.3.2
       prettier:
         specifier: ^3.5.3
         version: 3.5.3
@@ -132,6 +141,9 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@chatmcp/sdk@1.0.6':
+    resolution: {integrity: sha512-EBH6iDHd6k8o8yUZhF67+9LCTMlU3AL8/YSBfpqVAI1e2vW2+iRiMfXlmi02HdZzycybFkT+QXeagAMzwyg8yg==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -1238,6 +1250,9 @@ packages:
   '@types/minimatch@3.0.5':
     resolution: {integrity: sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==}
 
+  '@types/node-fetch@2.6.12':
+    resolution: {integrity: sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==}
+
   '@types/node@22.13.13':
     resolution: {integrity: sha512-ClsL5nMwKaBRwPcCvH8E7+nU4GxHVx1axNvMZTFHMEfNI7oahimt26P5zjVCRrjiIWj6YFXfE1v3dEp94wLcGQ==}
 
@@ -1447,6 +1462,9 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   atomically@2.0.3:
     resolution: {integrity: sha512-kU6FmrwZ3Lx7/7y3hPS5QnbJfaohcIul5fGqf7ok+4KklIEk9tJ0C2IQPdacSbVUWv6zVHXEBWoWd6NrVMT7Cw==}
 
@@ -1466,6 +1484,10 @@ packages:
 
   body-parser@2.1.0:
     resolution: {integrity: sha512-/hPxh61E+ll0Ujp24Ilm64cykicul1ypfwjVttduAiEdtnJFvLePSrIPk+HMImtNv5270wOGCb1Tns2rybMkoQ==}
+    engines: {node: '>=18'}
+
+  body-parser@2.2.0:
+    resolution: {integrity: sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==}
     engines: {node: '>=18'}
 
   brace-expansion@1.1.11:
@@ -1566,6 +1588,10 @@ packages:
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   commander@13.1.0:
     resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
     engines: {node: '>=18'}
@@ -1620,6 +1646,10 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
   debounce-fn@5.1.2:
     resolution: {integrity: sha512-Sr4SdOZ4vw6eQDvPYNxHogvrxmCIld/VenC5JbNrFwMiwd7lY/Z18ZFfo+EWNG4DD9nFlAujWAo/wGuOPHmy5A==}
     engines: {node: '>=12'}
@@ -1656,6 +1686,10 @@ packages:
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -1741,6 +1775,10 @@ packages:
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
   esbuild@0.25.1:
@@ -1850,6 +1888,10 @@ packages:
     resolution: {integrity: sha512-ORF7g6qGnD+YtUG9yx4DFoqCShNMmUKiXuT5oWMHiOvt/4WFbHC6yCwQMTSBMno7AqntNCAzzcnnjowRkTL9eQ==}
     engines: {node: '>= 18'}
 
+  express@5.1.0:
+    resolution: {integrity: sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==}
+    engines: {node: '>= 18'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -1871,6 +1913,10 @@ packages:
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
+
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -1902,6 +1948,14 @@ packages:
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
+
+  form-data@4.0.2:
+    resolution: {integrity: sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==}
+    engines: {node: '>= 6'}
+
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -1988,6 +2042,10 @@ packages:
 
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
   hasown@2.0.2:
@@ -2380,6 +2438,11 @@ packages:
   node-cleanup@2.1.2:
     resolution: {integrity: sha512-qN8v/s2PAJwGUtr1/hYTpNKlD6Y9rc4p8KSmJXyGdYGZsDGKXrGThikLFP9OCHFeLeEpQzPwiAtdIvBLqm//Hw==}
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
     engines: {node: 4.x || >=6.0.0}
@@ -2388,6 +2451,10 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   npm-run-path@5.3.0:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
@@ -2688,6 +2755,10 @@ packages:
     resolution: {integrity: sha512-/m/NSLxeYEgWNtyC+WtNHCF7jbGxOibVWKnn+1Psff4dJGOfoXP+MuC/f2CwSmyiHdOIzYnYFp4W6GxWfekaLA==}
     engines: {node: '>= 18'}
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -2716,6 +2787,10 @@ packages:
     resolution: {integrity: sha512-v67WcEouB5GxbTWL/4NeToqcZiAWEq90N888fczVArY8A79J0L4FD7vj5hm3eUMua5EpoQ59wa/oovY6TLvRUA==}
     engines: {node: '>= 18'}
 
+  send@1.2.0:
+    resolution: {integrity: sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==}
+    engines: {node: '>= 18'}
+
   serve-handler@6.1.6:
     resolution: {integrity: sha512-x5RL9Y2p5+Sh3D38Fh9i/iQ5ZK+e4xuXRd/pGbM4D13tgo/MGwbttUk8emytcr1YYzBYs+apnUngBDFYfpjPuQ==}
 
@@ -2725,6 +2800,10 @@ packages:
 
   serve-static@2.1.0:
     resolution: {integrity: sha512-A3We5UfEjG8Z7VkDv6uItWw6HY2bBSBJT1KtVESn6EOoOr2jAxNhxWCLY3jDE2WcuHXByWju74ck3ZgLwL8xmA==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.0:
+    resolution: {integrity: sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==}
     engines: {node: '>= 18'}
 
   setprototypeof@1.2.0:
@@ -2954,6 +3033,10 @@ packages:
     resolution: {integrity: sha512-gd0sGezQYCbWSbkZr75mln4YBidWUN60+devscpLF5mtRDUpiaTvKpBNrdaCvel1NdR2k6vclXybU5fBd2i+nw==}
     engines: {node: '>= 0.6'}
 
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
+
   typescript@5.8.2:
     resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
     engines: {node: '>=14.17'}
@@ -3088,6 +3171,10 @@ packages:
       jsdom:
         optional: true
 
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
+
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
@@ -3192,6 +3279,15 @@ snapshots:
       '@babel/helper-validator-identifier': 7.25.9
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@chatmcp/sdk@1.0.6':
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.9.0
+      content-type: 1.0.5
+      express: 5.1.0
+      raw-body: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -3501,8 +3597,8 @@ snapshots:
       cors: 2.8.5
       cross-spawn: 7.0.6
       eventsource: 3.0.5
-      express: 5.0.1
-      express-rate-limit: 7.5.0(express@5.0.1)
+      express: 5.1.0
+      express-rate-limit: 7.5.0(express@5.1.0)
       pkce-challenge: 5.0.0
       raw-body: 3.0.0
       zod: 3.24.2
@@ -4176,6 +4272,11 @@ snapshots:
 
   '@types/minimatch@3.0.5': {}
 
+  '@types/node-fetch@2.6.12':
+    dependencies:
+      '@types/node': 22.13.13
+      form-data: 4.0.2
+
   '@types/node@22.13.13':
     dependencies:
       undici-types: 6.20.0
@@ -4451,6 +4552,8 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  asynckit@0.4.0: {}
+
   atomically@2.0.3:
     dependencies:
       stubborn-fs: 1.2.5
@@ -4490,6 +4593,20 @@ snapshots:
       qs: 6.14.0
       raw-body: 3.0.0
       type-is: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  body-parser@2.2.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.0
+      http-errors: 2.0.0
+      iconv-lite: 0.6.3
+      on-finished: 2.4.1
+      qs: 6.14.0
+      raw-body: 3.0.0
+      type-is: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
@@ -4597,6 +4714,10 @@ snapshots:
 
   colorette@2.0.20: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   commander@13.1.0: {}
 
   concat-map@0.0.1: {}
@@ -4653,6 +4774,8 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  data-uri-to-buffer@4.0.1: {}
+
   debounce-fn@5.1.2:
     dependencies:
       mimic-fn: 4.0.0
@@ -4672,6 +4795,8 @@ snapshots:
   deep-eql@5.0.2: {}
 
   deep-is@0.1.4: {}
+
+  delayed-stream@1.0.0: {}
 
   depd@2.0.0: {}
 
@@ -4732,6 +4857,13 @@ snapshots:
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
 
   esbuild@0.25.1:
     optionalDependencies:
@@ -4880,6 +5012,10 @@ snapshots:
     dependencies:
       express: 5.0.1
 
+  express-rate-limit@7.5.0(express@5.1.0):
+    dependencies:
+      express: 5.1.0
+
   express@4.21.2:
     dependencies:
       accepts: 1.3.8
@@ -4953,6 +5089,38 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  express@5.1.0:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.0
+      content-disposition: 1.0.0
+      content-type: 1.0.5
+      cookie: 0.7.1
+      cookie-signature: 1.2.2
+      debug: 4.4.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.0
+      fresh: 2.0.0
+      http-errors: 2.0.0
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.1
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.14.0
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.1.0
+      serve-static: 2.2.0
+      statuses: 2.0.1
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   fast-deep-equal@3.1.3: {}
 
   fast-fifo@1.3.2: {}
@@ -4974,6 +5142,11 @@ snapshots:
   fastq@1.19.1:
     dependencies:
       reusify: 1.1.0
+
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -5022,6 +5195,17 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
+
+  form-data@4.0.2:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      mime-types: 2.1.35
+
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
 
   forwarded@0.2.0: {}
 
@@ -5099,6 +5283,10 @@ snapshots:
   has-flag@4.0.0: {}
 
   has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
 
   hasown@2.0.2:
     dependencies:
@@ -5488,11 +5676,19 @@ snapshots:
 
   node-cleanup@2.1.2: {}
 
+  node-domexception@1.0.0: {}
+
   node-fetch@2.7.0(encoding@0.1.13):
     dependencies:
       whatwg-url: 5.0.0
     optionalDependencies:
       encoding: 0.1.13
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   npm-run-path@5.3.0:
     dependencies:
@@ -5778,6 +5974,16 @@ snapshots:
       parseurl: 1.3.3
       path-to-regexp: 8.2.0
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.0
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.2.0
+    transitivePeerDependencies:
+      - supports-color
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -5831,6 +6037,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  send@1.2.0:
+    dependencies:
+      debug: 4.4.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.0
+      mime-types: 3.0.1
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   serve-handler@6.1.6:
     dependencies:
       bytes: 3.0.0
@@ -5856,6 +6078,15 @@ snapshots:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 1.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.0:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.0
     transitivePeerDependencies:
       - supports-color
 
@@ -6080,6 +6311,12 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.1
 
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.1
+
   typescript@5.8.2: {}
 
   uint8-varint@2.0.4:
@@ -6193,6 +6430,8 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  web-streams-polyfill@3.3.3: {}
 
   webidl-conversions@3.0.1: {}
 

--- a/src/core/server/config.ts
+++ b/src/core/server/config.ts
@@ -1,12 +1,16 @@
 import 'dotenv/config';
 import { McpServerConfig } from './types.js';
+// Required for REST transport mode in MCP.so Cloud
+import { getParamValue } from '@chatmcp/sdk/utils/index.js';
 
 export const loadConfig = (): McpServerConfig => {
-  const port = parseInt(process.env.MCP_SERVER_PORT || '3001', 10);
+  const port = parseInt(getParamValue('port') || process.env.MCP_SERVER_PORT || '3001', 10);
   const host = process.env.MCP_SERVER_HOST?.trim() || '0.0.0.0';
   const connectionTimeoutMs = parseInt(process.env.MCP_CONNECTION_TIMEOUT || '30000', 10);
-  const transportMode = process.env.MCP_TRANSPORT_MODE?.trim() || 'stdio';
+  const transportMode =
+    getParamValue('transportMode') || process.env.MCP_TRANSPORT_MODE?.trim() || 'stdio';
   const maxFileSizeBytes = parseInt(process.env.MAX_FILE_SIZE || '104857600', 10);
+  const endpoint = getParamValue('endpoint') || process.env.MCP_ENDPOINT?.trim() || '/rest';
 
   if (isNaN(port) || port < 0 || port > 65535) {
     throw new Error('Invalid port number');
@@ -16,7 +20,7 @@ export const loadConfig = (): McpServerConfig => {
     throw new Error('Invalid connection timeout');
   }
 
-  if (transportMode !== 'stdio' && transportMode !== 'sse') {
+  if (transportMode !== 'stdio' && transportMode !== 'sse' && transportMode !== 'rest') {
     throw new Error('Invalid transport mode');
   }
 
@@ -28,7 +32,8 @@ export const loadConfig = (): McpServerConfig => {
     port,
     host,
     connectionTimeoutMs,
-    transportMode,
+    transportMode: transportMode as 'stdio' | 'sse' | 'rest',
     maxFileSizeBytes,
+    endpoint: endpoint || '/',
   };
 };

--- a/src/core/server/index.ts
+++ b/src/core/server/index.ts
@@ -2,6 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { registerTools } from './tools/index.js';
 import { startStdioTransport } from './transports/stdio.js';
 import { startSSETransport } from './transports/sse.js';
+import { startRestTransport } from './transports/rest.js';
 import { McpServerConfig } from './types.js';
 import { StorageConfig } from '../storage/types.js';
 /**
@@ -26,6 +27,8 @@ async function startMCPServer(mcpConfig: McpServerConfig, storageConfig: Storage
 
     if (mcpConfig.transportMode === 'sse') {
       await startSSETransport(server, mcpConfig);
+    } else if (mcpConfig.transportMode === 'rest') {
+      await startRestTransport(server, mcpConfig);
     } else {
       await startStdioTransport(server, mcpConfig);
     }

--- a/src/core/server/transports/rest.ts
+++ b/src/core/server/transports/rest.ts
@@ -1,0 +1,41 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { McpServerConfig } from '../types.js';
+import { RestServerTransport } from '@chatmcp/sdk/server/rest.js';
+
+/**
+ * Connect the MCP server to the REST transport.
+ * The REST transport enables communication through HTTP REST API endpoints.
+ * This is particularly useful for remote integrations and web applications.
+ *
+ * Advantages of using REST transport:
+ * - Network-accessible API endpoints
+ * - Standard HTTP/HTTPS protocol
+ * - Support for concurrent requests
+ * - Easy integration with web services
+ * - Compatible with various client implementations
+ *
+ * See https://docs.mcp.so/server-hosting for more information.
+ *
+ * @param mcpServer - The MCP server instance
+ * @param config - The MCP server configuration
+ * @returns The MCP server and transport instance
+ */
+export const startRestTransport = async (mcpServer: McpServer, config: McpServerConfig) => {
+  try {
+    const transport = new RestServerTransport({
+      port: config.port,
+      endpoint: config.endpoint,
+    });
+
+    await mcpServer.connect(transport);
+
+    await transport.startServer();
+
+    return { mcpServer, transport };
+  } catch (error) {
+    throw new Error(
+      `Starting REST server: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error }
+    );
+  }
+};

--- a/src/core/server/types.ts
+++ b/src/core/server/types.ts
@@ -7,13 +7,15 @@ export interface McpServerConfig {
   /** Connection timeout in milliseconds */
   connectionTimeoutMs: number;
   /** Transport mode */
-  transportMode: 'stdio' | 'sse';
+  transportMode: 'stdio' | 'sse' | 'rest';
   /** Port number */
   port: number;
   /** Host name */
   host: string;
   /** Maximum file size in bytes */
   maxFileSizeBytes: number;
+  /** REST endpoint */
+  endpoint?: string;
 }
 
 /**

--- a/src/core/storage/config.ts
+++ b/src/core/storage/config.ts
@@ -2,6 +2,8 @@ import 'dotenv/config';
 import { Signer } from '@ucanto/principal/ed25519';
 import { StorageConfig } from './types.js';
 import { parseDelegation } from './utils.js';
+// Required for REST transport mode in MCP.so Cloud
+import { getParamValue } from '@chatmcp/sdk/utils/index.js';
 
 /**
  * Default gateway URL for the MCP server.
@@ -10,18 +12,20 @@ import { parseDelegation } from './utils.js';
 export const DEFAULT_GATEWAY_URL = 'https://storacha.link';
 
 export const loadConfig = async (): Promise<StorageConfig> => {
-  const privateKey = process.env.PRIVATE_KEY?.trim();
+  const privateKey = getParamValue('privateKey') || process.env.PRIVATE_KEY?.trim();
   if (!privateKey) {
     throw new Error('PRIVATE_KEY environment variable is required');
   }
-  const delegationStr = process.env.DELEGATION?.trim();
+  const delegationStr = getParamValue('delegation') || process.env.DELEGATION?.trim();
   if (!delegationStr) {
     throw new Error('DELEGATION environment variable is required');
   }
 
   const signer = Signer.parse(privateKey);
   const delegation = await parseDelegation(delegationStr);
-  const gatewayUrl = new URL(process.env.GATEWAY_URL?.trim() || DEFAULT_GATEWAY_URL);
+  const gatewayUrl = new URL(
+    getParamValue('gatewayUrl') || process.env.GATEWAY_URL?.trim() || DEFAULT_GATEWAY_URL
+  );
 
   return {
     signer,

--- a/test/integration/rest-mcp-server.test.ts
+++ b/test/integration/rest-mcp-server.test.ts
@@ -1,0 +1,357 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { getTestEnv, TEST_FILEPATH } from './test-config.js';
+import fetch from 'node-fetch';
+import { spawn, ChildProcess } from 'child_process';
+
+// Skip tests if running in CI environment
+// These tests require specific environment configuration and external services
+// that might not be available in CI environments
+const isCI = process.env.CI === 'true';
+(isCI ? describe.skip : describe)('MCP Server REST Integration Tests', () => {
+  let testFileContent: string;
+  let testFileBase64: string = '';
+  console.log('testFileBase64', testFileBase64);
+  let serverProcess: ChildProcess;
+  let baseUrl: string;
+  const PORT = 3001; // Specific port for REST tests
+
+  // Helper function to wait for a specified time
+  const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+  // Helper function to send POST requests to the server
+  const post = async (url: string, body: any) => {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: body.id,
+        method: body.method,
+        params: body.params,
+      }),
+    });
+    return response;
+  };
+
+  // Helper function to check if server is ready using POST
+  const isServerReady = async (url: string) => {
+    try {
+      // Use a JSON-RPC initialize to check if the server is alive
+      const requestBody = {
+        id: 'test',
+        method: 'initialize',
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: {
+            name: 'test',
+            version: '1.0.0',
+          },
+        },
+      };
+
+      const response = await post(url, requestBody);
+      let responseText;
+      try {
+        responseText = await response.text();
+        console.log(`Raw response: ${responseText}`);
+      } catch (err) {
+        console.log(`Error reading response text: ${err}`);
+      }
+
+      const data = responseText ? JSON.parse(responseText) : null;
+      console.log('Server response:', JSON.stringify(data));
+      return data?.result && data.result.serverInfo;
+    } catch (error: any) {
+      console.log(`Server check failed: ${error.message}`);
+      if (error.cause) {
+        console.log(`Cause: ${error.cause}`);
+      }
+      return false;
+    }
+  };
+
+  // Create a test file in memory and start server
+  beforeAll(async () => {
+    console.log('Starting REST integration test setup');
+
+    // Create an in-memory test file
+    testFileContent = 'This is a test file for upload';
+    testFileBase64 = Buffer.from(testFileContent).toString('base64');
+
+    // Set up environment variables for the server
+    const env = {
+      ...process.env,
+      ...getTestEnv(),
+      NODE_ENV: 'development',
+      MCP_TRANSPORT_MODE: 'rest', // Use REST mode
+      MCP_SERVER_PORT: PORT.toString(),
+    };
+
+    console.log(
+      'Starting server with env:',
+      JSON.stringify({
+        NODE_ENV: env.NODE_ENV,
+        MCP_TRANSPORT_MODE: env.MCP_TRANSPORT_MODE,
+        MCP_SERVER_PORT: env.MCP_SERVER_PORT,
+        PRIVATE_KEY: env.PRIVATE_KEY ? 'set' : 'not set',
+        DELEGATION: env.DELEGATION ? 'set' : 'not set',
+      })
+    );
+
+    // Start the server as a separate process
+    serverProcess = spawn('node', ['dist/index.js'], {
+      env,
+      stdio: 'pipe',
+    });
+
+    // Add listeners for server process output
+    serverProcess.stdout?.on('data', data => {
+      console.log(`Server stdout: ${data}`);
+    });
+
+    serverProcess.stderr?.on('data', data => {
+      console.log(`Server stderr: ${data}`);
+    });
+
+    serverProcess.on('error', error => {
+      console.error(`Server process error: ${error.message}`);
+    });
+
+    // Wait for the server to start with retries
+    baseUrl = `http://localhost:${PORT}/rest`;
+    const maxRetries = 5;
+    let retries = 0;
+    let ready = false;
+
+    console.log(`Waiting for server to start at ${baseUrl}...`);
+
+    await wait(2000);
+
+    // Then check with retries
+    while (!ready && retries < maxRetries) {
+      console.log(`Checking if server is ready (attempt ${retries + 1}/${maxRetries})...`);
+      ready = await isServerReady(baseUrl);
+
+      if (!ready) {
+        console.log(`Server not ready yet, waiting...`);
+        await wait(1000);
+        retries++;
+      }
+    }
+
+    if (!ready) {
+      throw new Error(`Server failed to start after ${maxRetries} attempts`);
+    }
+
+    console.log('REST Server is ready for tests');
+  }, 60000);
+
+  afterAll(async () => {
+    console.log('Cleaning up after tests');
+    if (serverProcess) {
+      console.log('Terminating server process');
+      serverProcess.kill();
+    }
+  });
+
+  it('should list available tools', async () => {
+    console.log('Testing: list available tools');
+    const response = await post(baseUrl, {
+      id: 'test',
+      method: 'tools/list',
+      params: {},
+    });
+
+    expect(response.status).toBe(200);
+
+    // Get the response body
+    const responseText = await response.text();
+    console.log('Tools response text:', responseText);
+
+    const data = JSON.parse(responseText);
+
+    // Verify the response has the expected structure
+    expect(data).toHaveProperty('result');
+    expect(data.result).toHaveProperty('tools');
+    expect(Array.isArray(data.result.tools)).toBe(true);
+
+    // Check for the expected tools
+    const tools = data.result.tools || [];
+    expect(tools.some((tool: { name: string }) => tool.name === 'identity')).toBe(true);
+    expect(tools.some((tool: { name: string }) => tool.name === 'upload')).toBe(true);
+    expect(tools.some((tool: { name: string }) => tool.name === 'retrieve')).toBe(true);
+  });
+
+  it('should get identity information', async () => {
+    console.log('Testing: get identity information');
+    const response = await post(baseUrl, {
+      id: 'test',
+      method: 'tools/call',
+      params: {
+        name: 'identity',
+        arguments: {
+          random_string: 'random', // Dummy parameter
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+
+    // Get the response body
+    const responseText = await response.text();
+    console.log('Identity response text:', responseText);
+
+    const data = JSON.parse(responseText);
+
+    // Verify the response has the expected structure
+    expect(data).toHaveProperty('result');
+    expect(data.result).toHaveProperty('content');
+    expect(Array.isArray(data.result.content)).toBe(true);
+    expect(data.result.content.length).toBeGreaterThan(0);
+
+    // Get the tool result content
+    const content = data.result.content[0];
+    expect(content).toHaveProperty('type');
+    expect(content).toHaveProperty('text');
+
+    // Parse the text content and verify it's the identity info
+    const identityInfo = JSON.parse(content.text);
+    expect(identityInfo).toHaveProperty('id');
+    expect(identityInfo.id).toContain('did:key:');
+  });
+
+  it('should upload a file', async () => {
+    console.log('Testing: upload a file');
+    const response = await post(baseUrl, {
+      id: 'test',
+      method: 'tools/call',
+      params: {
+        name: 'upload',
+        arguments: {
+          file: testFileBase64, // Send as base64 string
+          name: 'test-file.txt',
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+
+    // Get the response body
+    const responseText = await response.text();
+    console.log('Upload response text:', responseText);
+
+    const data = JSON.parse(responseText);
+
+    // Verify the response has the expected structure
+    expect(data).toHaveProperty('result');
+    expect(data.result).toHaveProperty('content');
+    expect(Array.isArray(data.result.content)).toBe(true);
+    expect(data.result.content.length).toBeGreaterThan(0);
+
+    // Get the content
+    const content = data.result.content[0];
+    expect(content).toHaveProperty('type');
+    expect(content).toHaveProperty('text');
+
+    // Parse the text content and verify it's the upload result
+    const uploadResult = JSON.parse(content.text);
+    expect(uploadResult).toHaveProperty('root');
+    expect(uploadResult.root).toBeDefined();
+    expect(uploadResult).toHaveProperty('url');
+    expect(uploadResult).toHaveProperty('files');
+
+    // Test that files is an object with at least one entry
+    expect(typeof uploadResult.files).toBe('object');
+    expect(uploadResult.files).not.toBeNull();
+
+    // Get the first file entry
+    const fileEntries = Object.entries(uploadResult.files);
+    expect(fileEntries.length).toBeGreaterThan(0);
+    expect(fileEntries[0]).toBeDefined();
+  }, 30000); // Increase the timeout for upload test
+
+  it('should retrieve a file', async () => {
+    console.log('Testing: retrieve a file');
+    const response = await post(baseUrl, {
+      id: 'test',
+      method: 'tools/call',
+      params: {
+        name: 'retrieve',
+        arguments: {
+          filepath: TEST_FILEPATH,
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+
+    // Get the response body
+    const responseText = await response.text();
+    console.log('Retrieve response text:', responseText);
+
+    const data = JSON.parse(responseText);
+
+    // Verify the response has the expected structure
+    expect(data).toHaveProperty('result');
+    expect(data.result).toHaveProperty('content');
+    expect(Array.isArray(data.result.content)).toBe(true);
+    expect(data.result.content.length).toBeGreaterThan(0);
+
+    // Get the content
+    const content = data.result.content[0];
+    expect(content).toHaveProperty('type');
+    expect(content).toHaveProperty('text');
+
+    // Just verify we have content
+    expect(content.text).toBeTruthy();
+  }, 30000);
+
+  it('should handle invalid upload parameters', async () => {
+    console.log('Testing: invalid upload parameters');
+    const response = await post(baseUrl, {
+      id: 'test',
+      method: 'tools/call',
+      params: {
+        name: 'upload',
+        arguments: {
+          // Missing required parameters
+        },
+      },
+    });
+
+    // For invalid parameters, we expect an error response with error details
+    const responseText = await response.text();
+    console.log('Invalid upload response text:', responseText);
+
+    const data = JSON.parse(responseText);
+    expect(data).toHaveProperty('error');
+  });
+
+  it('should handle invalid retrieve parameters', async () => {
+    console.log('Testing: invalid retrieve parameters');
+    const response = await post(baseUrl, {
+      id: 'test',
+      method: 'tools/call',
+      params: {
+        name: 'retrieve',
+        arguments: {
+          filepath: 'invalid-cid', // Missing the required filename structure
+        },
+      },
+    });
+
+    // For invalid parameters, we expect a response with an error content
+    const responseText = await response.text();
+    console.log('Invalid retrieve response text:', responseText);
+
+    const data = JSON.parse(responseText);
+
+    // Retrieve tool returns error as part of content
+    expect(data).toHaveProperty('result');
+    expect(data.result).toHaveProperty('content');
+    expect(data.result.content[0]).toHaveProperty('error', true);
+  });
+});

--- a/test/unit/core/server/config.test.ts
+++ b/test/unit/core/server/config.test.ts
@@ -28,6 +28,7 @@ describe('Server Configuration', () => {
       connectionTimeoutMs: 30000,
       transportMode: 'stdio',
       maxFileSizeBytes: 1024 * 1024 * 100, // 100MB
+      endpoint: '/rest',
     });
   });
 
@@ -39,6 +40,7 @@ describe('Server Configuration', () => {
       connectionTimeoutMs: 30000,
       transportMode: 'stdio',
       maxFileSizeBytes: 1024 * 1024 * 100, // 100MB
+      endpoint: '/rest',
     });
   });
 
@@ -88,6 +90,7 @@ describe('Server Configuration', () => {
       connectionTimeoutMs: 30000,
       maxFileSizeBytes: 1024 * 1024 * 100, // 100MB
       transportMode: 'stdio',
+      endpoint: '/rest',
     });
   });
 
@@ -102,6 +105,7 @@ describe('Server Configuration', () => {
       connectionTimeoutMs: 30000,
       maxFileSizeBytes: 1024 * 1024 * 100, // 100MB
       transportMode: 'stdio',
+      endpoint: '/rest',
     });
   });
 });

--- a/test/unit/core/server/index.test.ts
+++ b/test/unit/core/server/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { startStdioTransport } from '../../../../src/core/server/transports/stdio.js';
 import { startSSETransport } from '../../../../src/core/server/transports/sse.js';
+import { startRestTransport } from '../../../../src/core/server/transports/rest.js';
 import { McpServerConfig } from '../../../../src/core/server/types.js';
 import startMCPServer from '../../../../src/core/server/index.js';
 import { registerTools } from '../../../../src/core/server/tools/index.js';
@@ -15,6 +16,10 @@ vi.mock('../../../../src/core/server/transports/stdio.js', () => ({
 
 vi.mock('../../../../src/core/server/transports/sse.js', () => ({
   startSSETransport: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock('../../../../src/core/server/transports/rest.js', () => ({
+  startRestTransport: vi.fn().mockResolvedValue({}),
 }));
 
 // Mock the tools registration
@@ -41,6 +46,7 @@ describe('MCP Server', () => {
     host: 'localhost',
     connectionTimeoutMs: 30000,
     transportMode: 'stdio',
+    endpoint: '/',
     maxFileSizeBytes: 1024 * 1024 * 10, // 10MB
   };
 
@@ -71,6 +77,7 @@ describe('MCP Server', () => {
     expect(registerTools).toHaveBeenCalled();
     expect(startStdioTransport).toHaveBeenCalled();
     expect(startSSETransport).not.toHaveBeenCalled();
+    expect(startRestTransport).not.toHaveBeenCalled();
   });
 
   it('should initialize server with SSE transport', async () => {
@@ -80,6 +87,18 @@ describe('MCP Server', () => {
 
     expect(registerTools).toHaveBeenCalled();
     expect(startSSETransport).toHaveBeenCalled();
+    expect(startStdioTransport).not.toHaveBeenCalled();
+    expect(startRestTransport).not.toHaveBeenCalled();
+  });
+
+  it('should initialize server with REST transport', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await startMCPServer({ ...mockConfig, transportMode: 'rest' }, mockStorageConfig);
+
+    expect(registerTools).toHaveBeenCalled();
+    expect(startRestTransport).toHaveBeenCalled();
+    expect(startSSETransport).not.toHaveBeenCalled();
     expect(startStdioTransport).not.toHaveBeenCalled();
   });
 

--- a/test/unit/core/server/transports/rest.test.ts
+++ b/test/unit/core/server/transports/rest.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { startRestTransport } from '../../../../../src/core/server/transports/rest.js';
+import { McpServerConfig } from '../../../../../src/core/server/types.js';
+import { RestServerTransport } from '@chatmcp/sdk/server/rest.js';
+
+// Mock dependencies
+vi.mock('@chatmcp/sdk/server/rest.js');
+vi.mock('@modelcontextprotocol/sdk/server/mcp.js');
+
+describe('REST Transport', () => {
+  let mockServer: any;
+  let mockConfig: McpServerConfig;
+  let mockTransport: any;
+
+  beforeEach(() => {
+    // Reset all mocks
+    vi.clearAllMocks();
+
+    // Setup mock server
+    mockServer = {
+      connect: vi.fn(),
+    };
+
+    // Setup mock config
+    mockConfig = {
+      host: 'localhost',
+      port: 3000,
+      connectionTimeoutMs: 5000,
+      transportMode: 'rest',
+      maxFileSizeBytes: 1024 * 1024 * 10, // 10MB
+      endpoint: '/rest',
+    };
+
+    // Setup mock transport
+    mockTransport = {
+      startServer: vi.fn().mockResolvedValue(undefined),
+    };
+
+    // Mock RestServerTransport constructor
+    (RestServerTransport as any).mockImplementation(() => mockTransport);
+  });
+
+  it('should initialize REST transport with correct configuration', async () => {
+    // Mock successful connection
+    mockServer.connect.mockResolvedValue(undefined);
+
+    const result = await startRestTransport(mockServer, mockConfig);
+
+    // Verify transport was created with correct options
+    expect(RestServerTransport).toHaveBeenCalledWith({
+      port: mockConfig.port,
+      endpoint: '/rest',
+    });
+
+    // Verify server was connected to transport
+    expect(mockServer.connect).toHaveBeenCalledWith(mockTransport);
+
+    // Verify REST server was started
+    expect(mockTransport.startServer).toHaveBeenCalled();
+
+    // Verify return value
+    expect(result).toEqual({
+      mcpServer: mockServer,
+      transport: mockTransport,
+    });
+  });
+
+  it('should handle connection errors gracefully', async () => {
+    // Mock connection error
+    const error = new Error('Connection failed');
+    mockServer.connect.mockRejectedValue(error);
+
+    // Verify error is thrown
+    await expect(startRestTransport(mockServer, mockConfig)).rejects.toThrow('Connection failed');
+  });
+
+  it('should handle server start errors gracefully', async () => {
+    // Mock server start error
+    const error = new Error('Server start failed');
+    mockTransport.startServer.mockRejectedValue(error);
+
+    // Verify error is thrown
+    await expect(startRestTransport(mockServer, mockConfig)).rejects.toThrow('Server start failed');
+  });
+});

--- a/test/unit/core/server/transports/sse.test.ts
+++ b/test/unit/core/server/transports/sse.test.ts
@@ -49,6 +49,7 @@ describe('SSE Transport', () => {
       connectionTimeoutMs: 5000,
       transportMode: 'sse',
       maxFileSizeBytes: 1024 * 1024 * 10, // 10MB
+      endpoint: '/sse',
     };
 
     // Setup mock http server

--- a/test/unit/core/server/transports/stdio.test.ts
+++ b/test/unit/core/server/transports/stdio.test.ts
@@ -28,6 +28,7 @@ describe('Stdio Transport', () => {
       connectionTimeoutMs: 5000,
       transportMode: 'stdio',
       maxFileSizeBytes: 1024 * 1024 * 10, // 10MB
+      endpoint: '/',
     };
 
     // Setup mock transport


### PR DESCRIPTION
# Add REST Transport Mode Support to Storacha MCP Storage Server

## Overview
This PR adds full REST transport mode support to the Storacha MCP Storage Server, enabling network-accessible API endpoints that can be consumed by any HTTP client and facilitating deployment to MCP.so cloud hosting.

## Key Changes
- **REST Transport Implementation**: Enabled a REST transport layer for the MCP server that handles JSON-RPC over HTTP
- **Configuration Enhancements**: Updated the configuration system to properly detect and prioritize `MCP_TRANSPORT_MODE=rest` from environment variables
- **Docker Support**: Improved Dockerfile to work with pnpm and Node.js 22, ensuring containerized deployments function correctly
- **MCP.so Cloud Integration**: Added `chatmcp.yaml` configuration file for seamless deployment to MCP.so cloud hosting
- **Test Coverage**: Updated and expanded integration tests to verify REST transport functionality
- **Documentation**: Updated README.md and integrations.md with comprehensive REST mode usage instructions

## Benefits
- **Increased Accessibility**: Server can now be accessed over HTTP, making it compatible with a broader range of clients and languages
- **Cloud Ready**: Simple deployment to MCP.so cloud for increased availability and scalability
- **Improved Integration**: Much easier to integrate with web applications and third-party services
- **Containerization**: Docker support enables consistent deployment across various environments

## Testing
All integration tests have been updated and are passing, verifying the proper function of:
- Server initialization in REST mode
- Tool listing via REST transport
- Identity retrieval
- File upload operations
- File retrieval operations
- Error handling for invalid requests

## Usage Examples
```bash
# Run in REST mode
MCP_TRANSPORT_MODE=rest MCP_SERVER_PORT=3001 node dist/index.js

# With Docker
docker run -p 3001:3001 \
  -e PRIVATE_KEY="your_key" \
  -e DELEGATION="your_delegation" \
  -e MCP_TRANSPORT_MODE=rest \
  -e MCP_SERVER_PORT=3001 \
  storacha-mcp-server
```

MCP client configuration:
```json
{
  "mcpServers": {
    "storacha-storage-rest": {
      "url": "http://localhost:3001/rest"
    }
  }
}
```

Resolves: https://github.com/storacha/mcp-storage-server/issues/14